### PR TITLE
Update transformers to only use one schema for matching input contracts

### DIFF
--- a/lib/cards/transformer.json
+++ b/lib/cards/transformer.json
@@ -21,28 +21,8 @@
                 }
               }
             },
-            "trigger": {
-              "type": "object",
-              "properties": {
-                "before": {
-                  "anyOf": [
-                    {
-                      "type": "object"
-                    }, {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "after": {
-                  "anyOf": [
-                    {
-                      "type": "object"
-                    }, {
-                      "type": "null"
-                    }
-                  ]
-                }
-              }
+            "inputFilter": {
+              "type": "object"
             },
             "workerFilter": {
               "type": "object"
@@ -50,8 +30,8 @@
           },
           "required": [
             "requirements",
-            "trigger",
-            "image"
+            "inputFilter",
+            "workerFilter"
           ]
         }
       },


### PR DESCRIPTION
Instead of using `before` and `after` schemas, transformers will use
a single input schema, that will only be evaluated when a contract's `data.ready`
field switches from false to true.
Transformers are still in early alpha, so this is a patch change instead
of a major change.

Connects to https://github.com/product-os/jellyfish-worker/pull/386

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>