### PR TITLE
Define interface between JellyFish and Transformer-Runner

### DIFF
--- a/lib/cards/task.js
+++ b/lib/cards/task.js
@@ -13,7 +13,18 @@ module.exports = {
       type: 'object',
       properties: {
         data: {
-          type: 'object'
+          type: 'object',
+          required: ['transformer', 'input'],
+          properties: {
+            transformer: {
+              type: 'object',
+              $$formula: '$links["uses"][0].data.to' // how do we test this?
+            },
+            input: {
+              type: 'object',
+              $$formula: '$links["takes as input"][0].data.to' // how do we test this?
+            }
+          }
         }
       },
       required: [

--- a/lib/cards/task.spec.js
+++ b/lib/cards/task.spec.js
@@ -24,6 +24,8 @@ const jsonSchema = require('skhema')
 
 // ??? is there backflow for failed tasks?
 
+// ??? embedding the input means no updates after task creation. Is this exactly what we want, or unexpected?
+
 // we could use https://github.com/aspecto-io/genson-js or https://github.com/Nijikokun/generate-schema
 // to create the initial schema based on these examples
 


### PR DESCRIPTION
As JSON-schema is hard to read, let's define the interface between JF and the runner by creating examples which we can automatically verify against the actual scheme.

TODOs:
* [ ] add examples for all known states
* [ ] add tests to verify examples match schema (tests currently just fail because no schema validation implementation has been provided)
* [ ] adapt schemas to match examples