### PR TITLE
Remove redundant meta relationships

### DIFF
--- a/lib/cards/contract-repository.ts
+++ b/lib/cards/contract-repository.ts
@@ -40,19 +40,5 @@ export const contractRepository: ContractDefinition = {
 			},
 		},
 		indexed_fields: [['data.base_slug'], ['data.base_type']],
-		meta: {
-			relationships: [
-				{
-					title: 'Latest Version of the Repository',
-					link: 'latest',
-					// type: '*'
-				},
-				{
-					title: 'Repository contains contracts',
-					link: 'contains',
-					// type: '*'
-				},
-			],
-		},
 	},
 };

--- a/lib/cards/transformer-worker.ts
+++ b/lib/cards/transformer-worker.ts
@@ -81,14 +81,5 @@ export const transformerWorker: ContractDefinition = {
 			},
 			required: ['data'],
 		},
-		meta: {
-			relationships: [
-				{
-					title: 'Tasks',
-					link: 'owns',
-					type: 'task',
-				},
-			],
-		},
 	},
 };


### PR DESCRIPTION
These are now materialized automatically on the front-end using link constraints.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>