### PR TITLE
Add service-source mergeable

### DIFF
--- a/lib/cards/service-source.ts
+++ b/lib/cards/service-source.ts
@@ -23,6 +23,13 @@ export const serviceSource: ContractDefinition = {
 							type: 'object',
 							properties: {
 								...mergeProperties,
+								mergeable: {
+									description: 'all platforms have an image',
+									type: 'boolean',
+									$$formula: 'EVERY(VALUES(this.data.platforms), "image")',
+									readOnly: true,
+									default: false,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
Service source contract has a mergeable field, indicating whether all platforms have an image built.

Change-type: minor
Signed-off-by: Stathis Moraitidis <stathis@balena.io>