### PR TITLE
Add more loop contracts

### DIFF
--- a/lib/cards/index.ts
+++ b/lib/cards/index.ts
@@ -11,7 +11,11 @@ import { contractRepository } from './contract-repository';
 import { genericSource } from './generic-source';
 import { image } from './image';
 import { imageSource } from './image-source';
+import { loopBalenaIo } from './loop-balena-io';
+import { loopBalenalabs } from './loop-balenalabs';
+import { loopCompanyOs } from './loop-company-os';
 import { loopProductOs } from './loop-product-os';
+import { loopTeamOs } from './loop-team-os';
 import { roleLoop } from './role-loop';
 import { roleTransformerWorker } from './role-transformer-worker';
 import { service } from './service';
@@ -32,7 +36,11 @@ export const cards = [
 	genericSource,
 	image,
 	imageSource,
+	loopBalenaIo,
+	loopBalenalabs,
+	loopCompanyOs,
 	loopProductOs,
+	loopTeamOs,
 	roleLoop,
 	roleTransformerWorker,
 	task,

--- a/lib/cards/loop-balena-io.ts
+++ b/lib/cards/loop-balena-io.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const loopBalenaIo: ContractDefinition = {
+	slug: 'loop-balena-io',
+	name: 'balena-io',
+	type: 'loop@1.0.0',
+	data: {
+		roles: ['loop'],
+	},
+};

--- a/lib/cards/loop-balenalabs.ts
+++ b/lib/cards/loop-balenalabs.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const loopBalenalabs: ContractDefinition = {
+	slug: 'loop-balenalabs',
+	name: 'balenalabs',
+	type: 'loop@1.0.0',
+	data: {
+		roles: ['loop'],
+	},
+};

--- a/lib/cards/loop-company-os.ts
+++ b/lib/cards/loop-company-os.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const loopCompanyOs: ContractDefinition = {
+	slug: 'loop-company-os',
+	name: 'company-os',
+	type: 'loop@1.0.0',
+	data: {
+		roles: ['loop'],
+	},
+};

--- a/lib/cards/loop-team-os.ts
+++ b/lib/cards/loop-team-os.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const loopTeamOs: ContractDefinition = {
+	slug: 'loop-team-os',
+	name: 'team-os',
+	type: 'loop@1.0.0',
+	data: {
+		roles: ['loop'],
+	},
+};


### PR DESCRIPTION
In due course these loops should not be defined in this plugin. But for now we are  defining all loop contracts in `jellyfish-plugin-product-os` as we already know we need to move `loop-product-os` out of this plugin.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
