### PR TITLE
add formula version to enforce re-creation fo triggered actions

### DIFF
--- a/lib/cards/transformer-merge-properties.ts
+++ b/lib/cards/transformer-merge-properties.ts
@@ -8,6 +8,14 @@ const isDraftVersion = '/^[^+]*-/.test(contract.version)';
 const isFinalVersion = '!' + isDraftVersion;
 
 export const mergeProperties = {
+	// used to enforce triggered action re-creation after bug-fixes in the formula engine
+	formulaVersion: {
+		type: 'number',
+		$$formula: '1',
+		readOnly: true,
+		default: 0,
+	},
+
 	// this.links."was built from".merged
 	parentMerged: {
 		description: 'parent contract was already merged',


### PR DESCRIPTION
this is needed, because bug-fixes in Jellyscript change the triggered actions,
but not the types and therefore that code never gets executed

Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>