### PR TITLE
Use latest version of jellyfish-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.15",
-    "@balena/jellyfish-logger": "^4.0.40",
+    "@balena/jellyfish-logger": "^5.0.0",
     "@balena/jellyfish-worker": "^18.8.5",
     "lodash": "^4.17.21",
     "skhema": "^6.0.2"


### PR DESCRIPTION
This major version of the logger no longer handles uncaught exceptions, which would result in mangled and unreadable log messages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>